### PR TITLE
Add paint entries

### DIFF
--- a/.babelrc.js
+++ b/.babelrc.js
@@ -1,0 +1,20 @@
+module.exports = {
+  presets: [
+    [
+        require('@babel/preset-env'),
+            {
+                targets: {
+                    browsers: ['last 4 versions', 'not ie <= 10']
+                },
+            },
+        ],
+  ],
+  plugins: [
+    require('@babel/plugin-transform-spread'),
+    require('@babel/plugin-transform-parameters'),
+    require('@babel/plugin-syntax-dynamic-import'),
+    require('@babel/plugin-syntax-import-meta'),
+    [require('@babel/plugin-proposal-class-properties'), { loose: false }],
+    require('@babel/plugin-proposal-json-strings'),
+  ],
+};

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -44,7 +44,7 @@ jobs:
           command: echo -e $NPMRC > ~/.npmrc
       - run:
           name: Publish to NPM
-          command: npx published
+          command: npx published --git-tag
   glossary:
     <<: *defaults
     steps:

--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,1 @@
+* @fiverr/sre

--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -1,0 +1,18 @@
+---
+name: Bug report
+about: Create a report to help us improve
+
+---
+
+**Expected Behaviour**
+What did you expect the program to do?
+
+**Result**
+What did it actually do? Please include any output.
+
+**Reproduce**
+Describe the steps to reproduce:
+ - Browser and version
+ - Any additional logs may help (obscure secrets and keys)
+
+Add any other context about the problem.

--- a/.github/ISSUE_TEMPLATE/feature_request.md
+++ b/.github/ISSUE_TEMPLATE/feature_request.md
@@ -1,0 +1,10 @@
+---
+name: Feature request
+about: Suggest an idea for this project
+
+---
+
+**Describe your desired feature**
+Try to provide a clear and concise description of what you would have liked to be included or improved upon.
+
+\* If your feature request is related to a problem, consider a bug report.

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,0 +1,12 @@
+<!-- Please fill the following form (check what's relevant) -->
+
+- [ ] Bug fix
+- [ ] New feature
+- [ ] Breaking change
+- [ ] Deprecations
+- [ ] Tests added
+- [ ] JSDoc added
+
+Address issues: comma-separated list of issues addressed by the pull request, where applicable
+
+<!-- Describe your changes below in detail. -->

--- a/.npmignore
+++ b/.npmignore
@@ -1,5 +1,6 @@
 .*
 *.log
+CODE_OF_CONDUCT.md
 webpack.config.js
 spec.js
 index.html

--- a/.npmignore
+++ b/.npmignore
@@ -2,3 +2,4 @@
 *.log
 webpack.config.js
 spec.js
+index.html

--- a/.npmrc
+++ b/.npmrc
@@ -1,1 +1,2 @@
 package-lock=false
+access=public

--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -1,0 +1,13 @@
+# Contributor Code of Conduct
+
+We welcome contributors and maintainers.
+
+## Our Standards
+
+Be nice, helpful and, when needed, patient.
+
+## We are Responsible for contributors conduct
+
+Project maintainers are responsible for clarifying the standards of acceptable behaviour.
+
+Project maintainers have the right and responsibility to remove any content they consider inappropriate behaviour and to ban temporarily or permanently any contributor.

--- a/README.md
+++ b/README.md
@@ -15,9 +15,38 @@ pageTiming({metrics: [], reducer: () => {}, accumulator = []});
 
 | Key | Role | Type | Default value
 | - | - | - | -
-| `metrics` | The metrics you'd like to collect | Array | All browser performance metrics
+| `metrics` | The metrics you'd like to collect | Array | See full list below
 | `reducer` | The reducer used to collect them | Function | `(a, [k, v]) => [...a, [k, v]]`
 | `accumulator` | Initial data structure to reduce on | Any | `[]`
+
+### Metrics list
+
+##### Browser performance metrics
+- `connectEnd`
+- `connectStart`
+- `domComplete`
+- `domContentLoadedEventEnd`
+- `domContentLoadedEventStart`
+- `domInteractive`
+- `domLoading`
+- `domainLookupEnd`
+- `domainLookupStart`
+- `fetchStart`
+- `loadEventEnd`
+- `loadEventStart`
+- `navigationStart`
+- `redirectEnd`
+- `redirectStart`
+- `requestStart`
+- `responseEnd`
+- `responseStart`
+- `secureConnectionStart`
+- `unloadEventEnd`
+- `unloadEventStart`
+
+##### Paint entries
+- `first-paint`
+- `first-contentful-paint`
 
 ## Usage
 
@@ -26,9 +55,9 @@ pageTiming({metrics: [], reducer: () => {}, accumulator = []});
 import { pageTiming } from 'page-timing';
 const metrics = ['domInteractive', 'loadEventEnd'];
 
-pageTiming({metrics});
-
-console.log(...results);
+window.addEventListener('load', () => {
+  send(pageTiming({metrics}));
+});
 ```
 Output
 ```json
@@ -46,9 +75,11 @@ Output
 
 ### StatsD messages format
 ```js
+import {snakeCase} from 'lodash';
+
 const now = Date.now();
 const reducer = (accumulator, [key, value]) =>
-  [...accumulator, `browser_performance.${page_name}.${key}:${parseInt(value)}|ms`]
+  [...accumulator, `browser_performance.${page_name}.${snakeCase(key)}:${parseInt(value)}|ms`]
 ;
 const results = pageTiming({
     reducer,
@@ -60,8 +91,9 @@ sendMetricsToStatsD(...results);
 Output
 ```json
 [
-  "browser_performance.homepage_loggedout.domInteractive:208|ms",
-  "browser_performance.homepage_loggedout.loadEventEnd:431|ms"
+  "browser_performance.homepage_loggedout.dom_interactive:208|ms",
+  "browser_performance.homepage_loggedout.first_contentful_paint:316|ms",
+  "browser_performance.homepage_loggedout.load_event_end:431|ms"
 ]
 ```
 
@@ -97,7 +129,16 @@ Output
   "page": "homepage_loggedout"
 }
 ```
-## Calculations used to analyse the results
+
+## Dist
+Browser entry (dist) exposes method as `pageTiming.pageTiming`:
+
+```js
+window.pageTiming.pageTiming(); // [...]
+```
+
+
+## Calculations used to analyse the performance results
 
 | Meaning | Calculation
 | - | -

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
-# page-timing [![](https://img.shields.io/npm/v/page-timing.svg)](https://www.npmjs.com/package/page-timing) [![](https://img.shields.io/badge/source--000000.svg?logo=github&style=social)](https://github.com/fiverr/page-timing) [![](https://circleci.com/gh/fiverr/page-timing.svg?style=svg)](https://circleci.com/gh/fiverr/page-timing)
+# page-timing [![](https://img.shields.io/npm/v/page-timing.svg)](https://www.npmjs.com/package/page-timing) [![](https://img.shields.io/badge/source--000000.svg?logo=github&style=social)](https://github.com/fiverr/page-timing) [![](https://circleci.com/gh/fiverr/page-timing.svg?style=svg)](https://circleci.com/gh/fiverr/page-timing) [![](https://badgen.net/bundlephobia/minzip/page-timing)](https://bundlephobia.com/result?p=page-timing)
 
-Measure browser page performance timing and reduce it to a results object using the [navigation timing API](https://www.w3.org/TR/navigation-timing/)
+⏱ Measure browser page performance timing and reduce it to a results object using the [navigation timing API](https://www.w3.org/TR/navigation-timing/)
 
 This program collects each metrics' total time from `timeOrigin` (falls back to `navigationStart`), so metric calculations can be performed by the analyser, wherever the data is reported to.
 

--- a/index.html
+++ b/index.html
@@ -1,0 +1,22 @@
+<!DOCTYPE html>
+<html>
+	<head>
+		<meta charset="utf-8">
+        <meta http-equiv="X-UA-Compatible" content="IE=edge, chrome=1">
+        <title>page-timing</title>
+        <meta name="viewport" content="width=device-width, initial-scale=1, user-scalable=yes">
+	</head>
+	<body>
+    <h1>Page Title</h1>
+    <p>Some text</p>
+    <img src="https://dummyimage.com/1000x700/ffeedd/000000.png">
+    <script>
+      const end = Date.now() + 2000;
+      while(Date.now() < end) {/*...*/}
+    </script>
+    <script src="./dist/main.js"></script>
+    <script>
+      window.addEventListener('load', () => console.log(pageTiming.pageTiming()));
+    </script>
+	</body>
+</html>

--- a/package.json
+++ b/package.json
@@ -25,22 +25,30 @@
     "prepublishOnly": "npm run build",
     "build": "webpack --config webpack.config.js",
     "test": "NODE_ENV=test node --max_old_space_size=2048 ./node_modules/karma/bin/karma start .karma/index.js --loglevel debug",
-    "lint": "eslint -c .eslintrc.js 'src/*.js' 'src/**/*.js' --quiet"
+    "lint": "eslint -c .eslintrc.js 'src/*.js' 'src/**/*.js' --quiet",
+    "start": "NODE_ENV=development npm run build -- --watch & open index.html"
   },
   "devDependencies": {
-    "@babel/core": "^7.1.6",
-    "@fiverr/eslint-config-fiverr": "^2.0.0",
-    "babel-loader": "^8.0.4",
+    "@babel/core": "^7.2.2",
+    "@babel/plugin-proposal-class-properties": "^7.2.3",
+    "@babel/plugin-proposal-json-strings": "^7.2.0",
+    "@babel/plugin-syntax-dynamic-import": "^7.2.0",
+    "@babel/plugin-syntax-import-meta": "^7.2.0",
+    "@babel/plugin-transform-parameters": "^7.2.0",
+    "@babel/plugin-transform-spread": "^7.2.2",
+    "@babel/preset-env": "^7.2.3",
+    "@fiverr/eslint-config-fiverr": "^2.0.1",
+    "babel-loader": "^8.0.5",
     "chai": "^4.2.0",
-    "eslint": "^5.9.0",
-    "eslint-plugin-react": "^7.11.1",
-    "karma": "^3.1.3",
+    "eslint": "^5.12.0",
+    "eslint-plugin-react": "^7.12.3",
+    "karma": "^3.1.4",
     "karma-chrome-launcher": "^2.2.0",
     "karma-mocha": "^1.3.0",
     "karma-mocha-reporter": "^2.2.5",
     "karma-webpack": "^3.0.5",
     "mocha": "^5.2.0",
-    "webpack": "^4.26.1",
-    "webpack-cli": "^3.1.2"
+    "webpack": "^4.28.1",
+    "webpack-cli": "^3.2.1"
   }
 }

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "page-timing",
   "version": "1.0.4",
-  "description": "Measure browser timing and do something with it",
+  "description": "⏱ Measure browser timing and do something with it",
   "keywords": [
     "browser",
     "website",
@@ -10,7 +10,8 @@
     "speed",
     "loading",
     "navigation-timing",
-    "har"
+    "har",
+    "⏱"
   ],
   "author": "Fiverr SRE",
   "license": "MIT",

--- a/src/paint-entries/index.js
+++ b/src/paint-entries/index.js
@@ -1,0 +1,8 @@
+const all = () => window.performance.getEntriesByType ? window.performance.getEntriesByType('paint') : [];
+
+/**
+ * Retrieve all paint entries. Filter if needed
+ * @param  {String[]} metrics
+ * @return {String}
+ */
+export const paintEntries = (metrics) => metrics ? all().filter(({name}) => metrics.includes(name)) : all();

--- a/src/paint-entries/spec.js
+++ b/src/paint-entries/spec.js
@@ -1,0 +1,32 @@
+const { paintEntries } = require('.');
+
+describe('paint-entries', () => {
+    const getEntriesByType = window.performance.getEntriesByType;
+    before(() => {
+        window.performance.getEntriesByType = () => [
+            {
+                name: 'first-paint',
+                entryType: 'paint',
+                startTime: 2505276.299999998,
+                duration: 0,
+            },
+            {
+                name: 'first-contentful-paint',
+                entryType: 'paint',
+                startTime: 2505276.299999998,
+                duration: 0,
+            },
+        ];
+    });
+    after(() => {
+        window.performance.getEntriesByType = getEntriesByType;
+    });
+    it('Should report all reported paintEntries', () => {
+        const entries = paintEntries();
+        expect(entries).to.have.lengthOf(2);
+    });
+    it('Should filter only wanted metrics', () => {
+        const entries = paintEntries(['first-paint']);
+        expect(entries).to.have.lengthOf(1);
+    });
+});

--- a/src/paint-entries/spec.js
+++ b/src/paint-entries/spec.js
@@ -2,7 +2,7 @@ const { paintEntries } = require('.');
 
 describe('paint-entries', () => {
     const getEntriesByType = window.performance.getEntriesByType;
-    before(() => {
+    beforeEach(() => {
         window.performance.getEntriesByType = () => [
             {
                 name: 'first-paint',
@@ -20,6 +20,12 @@ describe('paint-entries', () => {
     });
     after(() => {
         window.performance.getEntriesByType = getEntriesByType;
+    });
+    it('Should return empty results if getEntriesByType is not available', () => {
+        delete window.performance.getEntriesByType;
+        const entries = paintEntries();
+        expect(entries).to.be.an('array');
+        expect(entries).to.have.lengthOf(0);
     });
     it('Should report all reported paintEntries', () => {
         const entries = paintEntries();

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -1,12 +1,13 @@
 const {resolve} = require('path');
+const {NODE_ENV = 'production'} = process.env;
 
 module.exports = {
-    mode: 'production',
+    mode: NODE_ENV,
     entry: './src/index.js',
     output: {
         path: resolve(__dirname, 'dist'),
         filename: 'main.js',
-        library: 'MyLibrary',
+        library: 'pageTiming',
         libraryTarget: 'umd2',
     },
     module: {
@@ -16,6 +17,7 @@ module.exports = {
                 loader: 'babel-loader',
                 include: resolve('../src'),
                 sideEffects: false,
+                options: require('./.babelrc.js'),
             },
         ],
     },


### PR DESCRIPTION
- Add [paint entries](https://developer.mozilla.org/en-US/docs/Web/API/PerformancePaintTiming) "first-paint" and "first-contentful-paint" (see full list below)

- Add experimentation page (`npm start`)
- Adjust dist to be ES5 compatible (babel)

Example default array after update
```json
0: (2) ["connectEnd", 4.382080078125]
1: (2) ["connectStart", 4.382080078125]
2: (2) ["domComplete", 2165.382080078125]
3: (2) ["domContentLoadedEventEnd", 2111.382080078125]
4: (2) ["domContentLoadedEventStart", 2111.382080078125]
5: (2) ["domInteractive", 2111.382080078125]
6: (2) ["domLoading", 25.382080078125]
7: (2) ["domainLookupEnd", 4.382080078125]
8: (2) ["domainLookupStart", 4.382080078125]
9: (2) ["fetchStart", 4.382080078125]
10: (2) ["loadEventStart", 2165.382080078125]
11: (2) ["requestStart", 4.382080078125]
12: (2) ["responseEnd", 15.382080078125]
13: (2) ["responseStart", 4.382080078125]
14: (2) ["unloadEventEnd", 19.382080078125]
15: (2) ["unloadEventStart", 19.382080078125]
16: (2) ["first-paint", 2049.8999999836087]
17: (2) ["first-contentful-paint", 2049.8999999836087]
```