### PR TITLE
Add metric for time elapsed since page origin

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,6 +35,7 @@ window.addEventListener(
 - `memory`: [Memory API information](https://developer.mozilla.org/en-US/docs/Web/API/Performance/memory)
 - `display`: Screen and document information
 - `dom`: Calculated metrics from the document object
+- `elapsed`: Time when the measurements were taken
 - `all`: A compound object containing all of the above
 - [`measure`](#measure): A helper function: Add measure entries to [navigation timing API](https://www.w3.org/TR/navigation-timing/)
 
@@ -97,6 +98,7 @@ window.addEventListener(
 | **dom** | `final_dom_node_count` | _number_ | Total number of nodes under the document object
 | **dom** | `final_dom_nest_depth` | _number_ | Highest nesting depth of DOM element under the document
 | **dom** | `final_html_size` | _number_ | Character count of the HTML document
+| **elapsed** | `page_time_elapsed` | _number_ | milliseconds elapsed since the time origin
 
 > † **contentful** element: A visible element which contains non empty text, media content or input.
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "page-timing",
-  "version": "2.0.1",
+  "version": "2.1.0",
   "description": "⏱ Collect and measure browser performance metrics",
   "keywords": [
     "browser",

--- a/src/all/index.js
+++ b/src/all/index.js
@@ -5,6 +5,7 @@ import { connection } from '../connection';
 import { memory } from '../memory';
 import { display } from '../display';
 import { dom } from '../dom';
+import { elapsed } from '../elapsed';
 
 /**
  * @returns {object}
@@ -17,5 +18,6 @@ export const all = () => Object.assign(
     connection(),
     memory(),
     display(),
-    dom()
+    dom(),
+    elapsed()
 );

--- a/src/all/spec.js
+++ b/src/all/spec.js
@@ -8,6 +8,7 @@ const connection = { connection: Symbol() };
 const memory = { memory: Symbol() };
 const display = { display: Symbol() };
 const dom = { dom: Symbol() };
+const elapsed = { elapsed: Symbol() };
 
 describe('all', () => {
     before(() => {
@@ -18,7 +19,8 @@ describe('all', () => {
             connection,
             memory,
             display,
-            dom
+            dom,
+            elapsed
         }).forEach(
             ([key, value]) => {
                 require(`../${key}`);
@@ -44,7 +46,8 @@ describe('all', () => {
                 ...connection,
                 ...memory,
                 ...display,
-                ...dom
+                ...dom,
+                ...elapsed
             }
         );
     });
@@ -57,7 +60,8 @@ describe('all', () => {
             connection,
             memory,
             display,
-            dom
+            dom,
+            elapsed
         ].forEach((item) => expect(all()).not.to.equal(item));
     });
 });

--- a/src/elapsed/index.js
+++ b/src/elapsed/index.js
@@ -1,0 +1,3 @@
+export const elapsed = () => ({
+    page_time_elapsed: window.performance.now()
+});

--- a/src/elapsed/spec.js
+++ b/src/elapsed/spec.js
@@ -1,0 +1,9 @@
+import { elapsed } from '.';
+
+describe('elapsed', () => {
+    it('should returned the time elapsed since the time origin', () => {
+        const { page_time_elapsed } = elapsed();
+        expect(page_time_elapsed).to.be.a('number');
+        expect(page_time_elapsed).to.be.at.least(50);
+    });
+});

--- a/src/index.js
+++ b/src/index.js
@@ -2,6 +2,7 @@ export { assets } from './assets';
 export { connection } from './connection';
 export { display } from './display';
 export { dom } from './dom';
+export { elapsed } from './elapsed';
 export { memory } from './memory';
 export { navigation } from './navigation';
 export { paint } from './paint';


### PR DESCRIPTION
Time elapsed allows us to have a relative point of comparison between the different measuring.

This can help with record cleanup (e.g. filter measurements from specific time points in the page) or with comparison of different values in different times in the page lifecycle