### PR TITLE
Add navigation metrics, add navigation type

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,6 +51,7 @@ window.addEventListener(
 | **navigation** | `fetch_start` | _number_ | Ready to fetch the document
 | **navigation** | `domain_lookup_start` | _number_ |
 | **navigation** | `domain_lookup_end` | _number_ |
+| **navigation** | `duration` | _number_ | Difference between responseEnd and startTime
 | **navigation** | `connect_start` | _number_ | Sent request to open a connection
 | **navigation** | `connect_end` | _number_ |
 | **navigation** | `secure_connection_start` | _number_ | Secure connection handshake
@@ -67,6 +68,7 @@ window.addEventListener(
 | **navigation** | `transfer_size` | _number_ | Size (octets) of response headers and payload body
 | **navigation** | `encoded_body_size` | _number_ | Size (octets) of _payload_ body
 | **navigation** | `decoded_body_size` | _number_ | Size (octets) of _message_ body
+| **navigation** | `worker_start` | _number_ | Time until service worker ran
 | **paint** | `first_paint` | _number_ | User agent first rendered after navigation
 | **paint** | `first_contentful_paint` | _number_ | Document contains at least one element that is paintable and contentful†
 | **assets** | `final_asset_javascript_count` | _number_ | Total **number** of Javascript resources
@@ -87,6 +89,7 @@ window.addEventListener(
 | **connection** | `effective_max_bandwidth` | _number_ | Mbps
 | **connection** | `reduced_data_usage` | _boolean_ | Vendor's "Data Saver" feature enables
 | **connection** | `round_trip_time` | _number_ | Estimated effective round-trip in ms
+| **connection** | `navigation_type` | _string_ | [navigate, reload, back_forward, prerender](https://w3c.github.io/navigation-timing/#dom-performancenavigationtiming-type)
 | **memory** | `js_heap_size_limit` | _number_ | Maximum bytes available for JS heap
 | **memory** | `total_js_heap_size` | _number_ | Total allocated bytes for JS heap
 | **memory** | `used_js_heap_size` | _number_ | Currently active bytes of JS heap

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "page-timing",
-  "version": "2.1.1",
+  "version": "2.2.0",
   "description": "⏱ Collect and measure browser performance metrics",
   "keywords": [
     "browser",
@@ -46,7 +46,7 @@
     "karma-mocha-reporter": "^2.2.5",
     "karma-webpack": "^4.0.2",
     "mocha": "^8.0.1",
-    "web-vitals": "^0.2.3",
+    "web-vitals": "^0.2.4",
     "webpack": "^4.43.0"
   }
 }

--- a/src/connection/index.js
+++ b/src/connection/index.js
@@ -1,21 +1,52 @@
 import { number } from '../number';
 
 /**
+ * Optional values of legacy navigation types
+ * 0: TYPE_NAVIGATE
+ * 1: TYPE_RELOAD
+ * 2: TYPE_BACK_FORWARD
+ * 255: TYPE_RESERVED
+ */
+const LEGACY_NAVIGATION_TYPES = [
+    'navigate',
+    'reload',
+    'back_forward'
+];
+
+/**
  * @see [NetworkInformation](https://developer.mozilla.org/en-US/docs/Web/API/NetworkInformation)
  * @returns {object}
  */
 export function connection() {
     const { connection } = window.navigator || {};
-    if (!connection) {
-        return {};
+    const result = {};
+
+    try {
+        const [
+            navigation = performance.navigation
+        ] = performance.getEntriesByType('navigation');
+
+        result.navigation_type = typeof navigation.type === 'number'
+            ? LEGACY_NAVIGATION_TYPES[navigation.type]
+            : navigation.type
+        ;
+    } catch (error) {
+        // ignore
     }
 
-    return {
-        connection_type: connection.type, // bluetooth, cellular, ethernet, none, wifi, wimax, other, unknown
-        effective_bandwidth: number(connection.downlink), // MBsS
-        effective_connection_type: connection.effectiveType, // slow-2g, 2g, 3g, 4g
-        effective_max_bandwidth: number(connection.downlinkMax), // MBsS
-        reduced_data_usage: connection.saveData, // boolean
-        round_trip_time: number(connection.rtt)
-    };
+    if (connection) {
+        Object.assign(
+            result,
+            {
+                connection_type: connection.type, // bluetooth, cellular, ethernet, none, wifi, wimax, other, unknown
+                effective_bandwidth: number(connection.downlink), // MBsS
+                effective_connection_type: connection.effectiveType, // slow-2g, 2g, 3g, 4g
+                effective_max_bandwidth: number(connection.downlinkMax), // MBsS
+                reduced_data_usage: connection.saveData, // boolean
+                round_trip_time: number(connection.rtt)
+            }
+        );
+    }
+
+    return result;
 }

--- a/src/connection/spec.js
+++ b/src/connection/spec.js
@@ -1,6 +1,24 @@
 import { connection } from '.';
 
+const { getEntriesByType } = window.performance;
+
 describe('connection', () => {
+    afterEach(() => {
+        window.performance.getEntriesByType = getEntriesByType;
+    });
+    it('should find navigation timing', () => {
+        const { navigation_type } = connection();
+
+        expect(navigation_type).to.equal('navigate');
+    });
+    it('should find navigation on legacy object', () => {
+        window.performance.getEntriesByType = () => [];
+        expect(performance.getEntriesByType('navigation')).to.have.lengthOf(0);
+        const { navigation_type } = connection();
+
+        expect(navigation_type).to.equal('navigate');
+    });
+
     it('should expose supported metrics', () => {
         const {
             connection_type,

--- a/src/navigation/index.js
+++ b/src/navigation/index.js
@@ -15,6 +15,7 @@ const METRICS = [
     'domContentLoadedEventStart',
     'domInteractive',
     'domLoading',
+    'duration',
     'encodedBodySize',
     'fetchStart',
     'loadEventEnd',
@@ -28,7 +29,8 @@ const METRICS = [
     'secureConnectionStart',
     'transferSize',
     'unloadEventEnd',
-    'unloadEventStart'
+    'unloadEventStart',
+    'workerStart'
 ];
 
 /**

--- a/src/navigation/spec.js
+++ b/src/navigation/spec.js
@@ -16,6 +16,7 @@ describe('navigation', () => {
         'dom_content_loaded_event_end',
         'dom_content_loaded_event_start',
         'dom_interactive',
+        'duration',
         'encoded_body_size',
         'fetch_start',
         'load_event_end',
@@ -28,7 +29,8 @@ describe('navigation', () => {
         'secure_connection_start',
         'transfer_size',
         'unload_event_end',
-        'unload_event_start'
+        'unload_event_start',
+        'worker_start'
     ].forEach(
         (event) => it(
             `${event} == number`,


### PR DESCRIPTION
Under "navigation":
- `duration` (_number_) Difference between responseEnd and startTime
- `worker_start` (_number_) Time until service worker ran

Under "connection":
- `navigation_type` (_string_) [navigate, reload, back_forward, prerender](https://w3c.github.io/navigation-timing/#dom-performancenavigationtiming-type)