### PR TITLE
Comply to ESM import syntax (required by webpack 5)

### DIFF
--- a/.karma/index.js
+++ b/.karma/index.js
@@ -16,7 +16,7 @@ module.exports = (config) => {
             singleRun: !watch,
             autoWatch: watch,
             basePath: '',
-            frameworks: ['mocha'],
+            frameworks: ['mocha', 'webpack'],
             browsers,
             browserNoActivityTimeout,
             port: 9876, // This is the default. Change it if you have ports collisions

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "page-timing",
-  "version": "2.2.1",
+  "version": "2.2.2",
   "description": "⏱ Collect and measure browser performance metrics",
   "keywords": [
     "browser",
@@ -38,15 +38,15 @@
     "@lets/sleep": "^1.0.0",
     "@lets/wait": "^2.0.2",
     "chai": "^4.2.0",
-    "eslint": "^7.10.0",
+    "eslint": "^7.11.0",
     "eslint-plugin-log": "^1.2.6",
     "karma": "^5.2.3",
     "karma-chrome-launcher": "^3.1.0",
     "karma-mocha": "^2.0.1",
     "karma-mocha-reporter": "^2.2.5",
-    "karma-webpack": "^4.0.2",
+    "karma-webpack": "^5.0.0-alpha.3.0",
     "mocha": "^8.1.3",
     "web-vitals": "^0.2.4",
-    "webpack": "^4.44.2"
+    "webpack": "^5.1.0"
   }
 }

--- a/spec-helpers/index.js
+++ b/spec-helpers/index.js
@@ -1,4 +1,6 @@
-export const getEntriesByTypeMock = (type) => require('./fixture.json').filter(
+import fixture from './fixture.json';
+
+export const getEntriesByTypeMock = (type) => fixture.filter(
     ({ entryType }) => entryType === type
 );
 
@@ -13,9 +15,3 @@ export const onload = () => new Promise((resolve) => {
         return false;
     }
 });
-
-export const purge = () => Object.keys(require.cache).forEach(
-    (key) => {
-        delete require.cache[key];
-    }
-);

--- a/src/all/index.js
+++ b/src/all/index.js
@@ -1,11 +1,11 @@
-import { navigation } from '../navigation';
-import { paint } from '../paint';
-import { assets } from '../assets';
-import { connection } from '../connection';
-import { memory } from '../memory';
-import { display } from '../display';
-import { dom } from '../dom';
-import { elapsed } from '../elapsed';
+import { navigation } from '../navigation/index.js';
+import { paint } from '../paint/index.js';
+import { assets } from '../assets/index.js';
+import { connection } from '../connection/index.js';
+import { memory } from '../memory/index.js';
+import { display } from '../display/index.js';
+import { dom } from '../dom/index.js';
+import { elapsed } from '../elapsed/index.js';
 
 /**
  * @returns {object}

--- a/src/all/spec.js
+++ b/src/all/spec.js
@@ -1,67 +1,33 @@
-import { purge } from '../../spec-helpers';
-
-let all;
-const navigation = { navigation: Symbol() };
-const paint = { paint: Symbol() };
-const assets = { assets: Symbol() };
-const connection = { connection: Symbol() };
-const memory = { memory: Symbol() };
-const display = { display: Symbol() };
-const dom = { dom: Symbol() };
-const elapsed = { elapsed: Symbol() };
+import { navigation } from '../navigation/index.js';
+import { paint } from '../paint/index.js';
+import { assets } from '../assets/index.js';
+import { connection } from '../connection/index.js';
+import { memory } from '../memory/index.js';
+import { display } from '../display/index.js';
+import { dom } from '../dom/index.js';
+import { elapsed } from '../elapsed/index.js';
+import { all } from './index.js';
 
 describe('all', () => {
-    before(() => {
-        Object.entries({
-            navigation,
-            paint,
-            assets,
-            connection,
-            memory,
-            display,
-            dom,
-            elapsed
-        }).forEach(
-            ([key, value]) => {
-                require(`../${key}`);
-                require.cache[require.resolve(`../${key}`)].exports = {
-                    [key]: () => value
-                };
-            }
-        );
-
-        all = require('.').all;
-    });
-    after(() => {
-        purge();
-    });
     it('should collect information from all modules', () => {
-        expect(
-            all()
-        ).to.deep.equal(
-            {
-                ...navigation,
-                ...paint,
-                ...assets,
-                ...connection,
-                ...memory,
-                ...display,
-                ...dom,
-                ...elapsed
-            }
-        );
-    });
+        const result = all();
+        const metrics = {
+            ...navigation(),
+            ...paint(),
+            ...assets(),
+            ...connection(),
+            ...memory(),
+            ...display(),
+            ...dom(),
+            ...elapsed()
+        };
 
-    it('should create a new object', () => {
-        [
-            navigation,
-            paint,
-            assets,
-            connection,
-            memory,
-            display,
-            dom,
-            elapsed
-        ].forEach((item) => expect(all()).not.to.equal(item));
+        expect(result.page_time_elapsed).to.be.a(typeof metrics.page_time_elapsed);
+        expect(result.page_time_elapsed).to.be.a('number');
+
+        delete result.page_time_elapsed;
+        delete metrics.page_time_elapsed;
+
+        expect(result).to.deep.equal(metrics);
     });
 });

--- a/src/assets/index.js
+++ b/src/assets/index.js
@@ -1,5 +1,5 @@
-import { getType } from '../get-type';
-import { number } from '../number';
+import { getType } from '../get-type/index.js';
+import { number } from '../number/index.js';
 
 const FINAL_ASSET_PREFIX = 'final_asset';
 

--- a/src/assets/spec.js
+++ b/src/assets/spec.js
@@ -1,5 +1,5 @@
-import { getEntriesByTypeMock } from '../../spec-helpers';
-import { assets } from '.';
+import { getEntriesByTypeMock } from '../../spec-helpers/index.js';
+import { assets } from './index.js';
 
 const { getEntriesByType } = window.performance;
 

--- a/src/connection/index.js
+++ b/src/connection/index.js
@@ -1,4 +1,4 @@
-import { number } from '../number';
+import { number } from '../number/index.js';
 
 /**
  * Optional values of legacy navigation types

--- a/src/connection/spec.js
+++ b/src/connection/spec.js
@@ -1,4 +1,4 @@
-import { connection } from '.';
+import { connection } from './index.js';
 
 const { getEntriesByType } = window.performance;
 

--- a/src/display/index.js
+++ b/src/display/index.js
@@ -1,4 +1,4 @@
-import { number } from '../number';
+import { number } from '../number/index.js';
 
 /**
  * @returns {object}

--- a/src/display/spec.js
+++ b/src/display/spec.js
@@ -1,4 +1,4 @@
-import { display } from '.';
+import { display } from './index.js';
 
 describe('display', () => {
     [

--- a/src/dom/index.js
+++ b/src/dom/index.js
@@ -1,4 +1,4 @@
-import { number } from '../number';
+import { number } from '../number/index.js';
 
 /**
  * getMaxNestLevel: Determine the largest DOM depth in the document or under a base element

--- a/src/dom/spec.js
+++ b/src/dom/spec.js
@@ -1,4 +1,4 @@
-import { dom } from '.';
+import { dom } from './index.js';
 
 let d;
 const { querySelector } = document;

--- a/src/elapsed/spec.js
+++ b/src/elapsed/spec.js
@@ -1,4 +1,4 @@
-import { elapsed } from '.';
+import { elapsed } from './index.js';
 
 const { now } = window.performance;
 

--- a/src/fps/spec.js
+++ b/src/fps/spec.js
@@ -1,4 +1,4 @@
-import { fps } from '.';
+import { fps } from './index.js';
 
 const { requestAnimationFrame } = window;
 
@@ -6,7 +6,7 @@ describe('fps', () => {
     afterEach(() => {
         window.requestAnimationFrame = requestAnimationFrame;
     });
-    it('should measure browser FTP', async() => {
+    it('should measure browser FPS', async() => {
         const result = await fps();
         expect(result).to.be.at.least(29);
         expect(result).to.be.at.most(62);

--- a/src/index.js
+++ b/src/index.js
@@ -1,12 +1,12 @@
-export { assets } from './assets';
-export { connection } from './connection';
-export { display } from './display';
-export { dom } from './dom';
-export { elapsed } from './elapsed';
-export { memory } from './memory';
-export { navigation } from './navigation';
-export { paint } from './paint';
+export { assets } from './assets/index.js';
+export { connection } from './connection/index.js';
+export { display } from './display/index.js';
+export { dom } from './dom/index.js';
+export { elapsed } from './elapsed/index.js';
+export { memory } from './memory/index.js';
+export { navigation } from './navigation/index.js';
+export { paint } from './paint/index.js';
 
-export { all } from './all';
-export { fps } from './fps';
-export { measure } from './measure';
+export { all } from './all/index.js';
+export { fps } from './fps/index.js';
+export { measure } from './measure/index.js';

--- a/src/measure/spec.js
+++ b/src/measure/spec.js
@@ -1,6 +1,6 @@
 import sleep from '@lets/sleep';
 import wait from '@lets/wait';
-import { measure } from '.';
+import { measure } from './index.js';
 
 describe('measure', () => {
     beforeEach(() => {

--- a/src/memory/index.js
+++ b/src/memory/index.js
@@ -1,5 +1,5 @@
-import { number } from '../number';
-import { snakeCase } from '../snake-case';
+import { number } from '../number/index.js';
+import { snakeCase } from '../snake-case/index.js';
 
 /**
  * @type {string[]}

--- a/src/memory/spec.js
+++ b/src/memory/spec.js
@@ -1,4 +1,4 @@
-import { memory } from '.';
+import { memory } from './index.js';
 
 let data;
 

--- a/src/navigation/index.js
+++ b/src/navigation/index.js
@@ -1,5 +1,5 @@
-import { number } from '../number';
-import { snakeCase } from '../snake-case';
+import { number } from '../number/index.js';
+import { snakeCase } from '../snake-case/index.js';
 
 /**
  * @type {string[]}

--- a/src/navigation/spec.js
+++ b/src/navigation/spec.js
@@ -1,4 +1,4 @@
-import { navigation } from '.';
+import { navigation } from './index.js';
 
 let data;
 

--- a/src/number/spec.js
+++ b/src/number/spec.js
@@ -1,4 +1,4 @@
-import { number } from '.';
+import { number } from './index.js';
 
 const REALLY_BIG_NUMBER = new Array(20).fill(1000).reduce((a, b) => a * b);
 

--- a/src/paint/index.js
+++ b/src/paint/index.js
@@ -1,5 +1,5 @@
-import { number } from '../number';
-import { snakeCase } from '../snake-case';
+import { number } from '../number/index.js';
+import { snakeCase } from '../snake-case/index.js';
 
 /**
  * Retrieve all paint entries

--- a/src/paint/spec.js
+++ b/src/paint/spec.js
@@ -1,5 +1,5 @@
-import { getEntriesByTypeMock } from '../../spec-helpers';
-import { paint } from '.';
+import { getEntriesByTypeMock } from '../../spec-helpers/index.js';
+import { paint } from './index.js';
 
 const { getEntriesByType } = window.performance;
 


### PR DESCRIPTION
Internal change.

Native ESM does not resolve directories. Webpack 5 complies with this module resolution rule.
```
Module not found: Error: Can't resolve '../relative' in '/some-dir'
Did you mean 'index.js'?
BREAKING CHANGE: The request '.' failed to resolve only because it was resolved as fully specified
(probably because the origin is a '*.mjs' file or a '*.js' file where the package.json contains '"type": "module"').
The extension in the request is mandatory for it to be fully specified.
Add the extension to the request.
```