### PR TITLE
Move to async interface

### DIFF
--- a/.karma/env-setup.js
+++ b/.karma/env-setup.js
@@ -1,7 +1,12 @@
+const chai = require('chai');
+const chaiAsPromised = require('chai-as-promised');
+
 Object.assign(
     global,
-    require('chai')
+    chai
 );
+
+chai.use(chaiAsPromised);
 
 /**
  * empty the document element

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,87 @@
+# 3.0.0
+
+## Breaking changes
+
+### Move to async interface
+All functions have transformed to async functions.
+
+By utilising PerformanceObserver, async interface allows to decouple from waiting for onload event. User can include an async file and not worry about loading time.
+
+Here are migration examples:
+
+#### Before
+```js
+const metrics = navigation();
+```
+
+#### After
+```js
+const metrics = await navigation();
+```
+
+#### Before
+```js
+window.addEventListener('load', () => send(all()), { once: true });
+```
+
+#### After
+No need to wait for window load
+```js
+all().then(send).catch(console.error);
+```
+
+#### Before
+```js
+const metrics = { ...paint(), ...navigation() };
+```
+
+#### After
+```js
+const metrics = Object.assign.apply(null, await Promise.all([ paint(), navigation() ]));
+```
+
+# 2.2.1
+
+## Fixes
+
+### Verify page_time_elapsed
+Should not send null value. The rest of the library sends `undefined` when no value is available so it gets dropped in JSON stringification.
+
+# 2.2.0
+
+## New features
+
+### Add navigation metrics
+- `duration`: Difference between responseEnd and startTime
+- `worker_start`: Time until service worker ran
+
+### Add connection type
+- `navigation_type`: [navigate, reload, back_forward, prerender](https://w3c.github.io/navigation-timing/#dom-performancenavigationtiming-type)
+
+# 2.1.1
+
+## Fixes
+
+### Verify numbers are safe
+Use max safe integer if result is higher
+
+# 2.1.0
+
+## New features
+
+### Add time elapsed
+Time elapsed allows us to have a relative point of comparison between the different measuring.
+
+- `page_time_elapsed`: milliseconds elapsed since the time origin
+
+# 2.0.1
+
+## Fixes
+Support for internet explorer Number functions (fallback from Number object to global functions)
+
+# 2.0.0
+
+## Breaking changes
+
+### New interface
+Completely new interface. Instead of a callback, expose functions that return structured data. It's different

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "page-timing",
-  "version": "3.0.0",
+  "version": "3.0.0-rc",
   "description": "⏱ Collect and measure browser performance metrics",
   "keywords": [
     "browser",
@@ -39,7 +39,7 @@
     "@lets/wait": "^2.0.2",
     "chai": "^4.2.0",
     "chai-as-promised": "^7.1.1",
-    "eslint": "^7.13.0",
+    "eslint": "^7.14.0",
     "eslint-plugin-log": "^1.2.6",
     "karma": "^5.2.3",
     "karma-chrome-launcher": "^3.1.0",
@@ -50,6 +50,6 @@
     "regenerator-runtime": "^0.13.7",
     "tti-polyfill": "^0.2.2",
     "web-vitals": "^1.0.1",
-    "webpack": "^5.5.1"
+    "webpack": "^5.9.0"
   }
 }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "page-timing",
-  "version": "3.0.0-rc",
+  "version": "3.0.0",
   "description": "⏱ Collect and measure browser performance metrics",
   "keywords": [
     "browser",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "page-timing",
-  "version": "2.2.2",
+  "version": "3.0.0",
   "description": "⏱ Collect and measure browser performance metrics",
   "keywords": [
     "browser",
@@ -38,16 +38,18 @@
     "@lets/sleep": "^1.0.0",
     "@lets/wait": "^2.0.2",
     "chai": "^4.2.0",
-    "eslint": "^7.11.0",
+    "chai-as-promised": "^7.1.1",
+    "eslint": "^7.13.0",
     "eslint-plugin-log": "^1.2.6",
     "karma": "^5.2.3",
     "karma-chrome-launcher": "^3.1.0",
     "karma-mocha": "^2.0.1",
     "karma-mocha-reporter": "^2.2.5",
     "karma-webpack": "^5.0.0-alpha.3.0",
-    "mocha": "^8.1.3",
+    "mocha": "^8.2.1",
+    "regenerator-runtime": "^0.13.7",
     "tti-polyfill": "^0.2.2",
-    "web-vitals": "^0.2.4",
-    "webpack": "^5.1.0"
+    "web-vitals": "^1.0.1",
+    "webpack": "^5.5.1"
   }
 }

--- a/play/index.html
+++ b/play/index.html
@@ -9,10 +9,20 @@
         <link rel="stylesheet" href="https://code.jquery.com/ui/jquery-ui-git.css">
         <style>
 * { font-family: monospace; }
+html { height: 100%; }
+body {
+    min-height: 100%;
+    display: flex;
+    justify-content: space-between;
+    margin: 0;
+    padding: 1em;
+}
+section {
+    overflow: auto;
+}
 table {
     border-collapse:
     collapse; float: right;
-    margin: 1em 1em 4em;
     border: 1px solid rgba(0, 0, 0, .1);
 }
 tr:nth-child(even) { background: rgba(0, 0, 0, .05) }
@@ -21,55 +31,21 @@ td { padding: .2em 1em }
         </style>
     </head>
     <body>
-    <table><tr><td>Loading...</tr><td></table>
-    <h1>Page Timing <a href="https://www.npmjs.com/package/page-timing" rel="nofollow"><img src="https://img.shields.io/npm/v/page-timing.svg"></a> <a href="https://github.com/fiverr/page-timing" rel="nofollow"><img src="https://img.shields.io/badge/source--000000.svg?logo=github&style=social"></a> <a href="https://circleci.com/gh/fiverr/page-timing" rel="nofollow"><img src="https://circleci.com/gh/fiverr/page-timing.svg?style=svg"></a> <a href="https://bundlephobia.com/result?p=page-timing" rel="nofollow"><img src="https://badgen.net/bundlephobia/minzip/page-timing"></a></h1>
-    <p>⏱ Collect and measure browser performance metrics</p>
-
-    <p><img src="https://dummyimage.com/1000x700/ffeedd/000000.png" width="100" alt="alt text"></p>
+        <section>
+            <h1>Page Timing</h1>
+            <p>
+                <a href="https://www.npmjs.com/package/page-timing" rel="nofollow"><img src="https://img.shields.io/npm/v/page-timing.svg"></a> <a href="https://github.com/fiverr/page-timing" rel="nofollow"><img src="https://img.shields.io/badge/source--000000.svg?logo=github&style=social"></a> <a href="https://circleci.com/gh/fiverr/page-timing" rel="nofollow"><img src="https://circleci.com/gh/fiverr/page-timing.svg?style=svg"></a> <a href="https://bundlephobia.com/result?p=page-timing" rel="nofollow"><img src="https://badgen.net/bundlephobia/minzip/page-timing"></a>
+            </p>
+            <p>⏱ Collect and measure browser performance metrics</p>
+            <p><img src="https://dummyimage.com/1000x700/ffeedd/000000.png" width="100" alt="alt text"></p>
+        </section>
+        <table><tr><td>Loading...</tr><td></table>
     <script>
         // Delay everything by 2 seconds
         const end = Date.now() + 2000;
         while(Date.now() < end) {/*...*/}
     </script>
     <script src="script.js"></script>
-    <script>
-        window.performance_information = {};
-        function print() {
-            document.querySelector('table').innerHTML = Object.entries(window.performance_information).map(
-                ([key, value]) => `<tr><td>${key}</td><td>${value}</td></tr>`
-            ).join('');
-        }
-
-        window.addEventListener(
-            'load',
-            () => {
-                Object.assign(window.performance_information, all());
-                print();
-                [
-                    [getLCP, 'largest_contentful_paint'],
-                    [getFID, 'first_input_delay'],
-                    [getCLS, 'comulative_layout_shift'],
-                ].forEach(
-                    ([ fn, name ]) => fn(
-                        ({ value }) => {
-                            window.performance_information[name] = value;
-                            print();
-                        }
-                    )
-                );
-
-                fps().then(result => {
-                    window.performance_information.frames_per_second = result;
-                    print()
-                })
-
-                TTI.getFirstConsistentlyInteractive().then(result => {
-                    window.performance_information.time_to_interactive = result;
-                    print()
-                })
-            }
-        );
-    </script>
     <script async>
         // Delay everything by 2 seconds
         const end = Date.now() + 2000;

--- a/play/script.js
+++ b/play/script.js
@@ -1,8 +1,44 @@
+import 'regenerator-runtime';
 import { getLCP, getFID, getCLS } from 'web-vitals';
 import TTI from 'tti-polyfill';
-import { measure, fps, all } from '../src/index.js';
+import { fps, all } from '../src/index.js';
 
-Object.assign(
-    window,
-    { measure, fps, all, getLCP, getFID, getCLS, TTI }
+window.performance_information = {};
+
+all().then((result) => {
+    console.log('all', performance.now());
+    Object.assign(window.performance_information, result);
+    print();
+});
+
+[
+    [getLCP, 'largest_contentful_paint'],
+    [getFID, 'first_input_delay'],
+    [getCLS, 'comulative_layout_shift']
+].forEach(
+    ([ fn, name ]) => fn(
+        ({ value }) => {
+            console.log(name, performance.now());
+            window.performance_information[name] = value;
+            print();
+        }
+    )
 );
+
+fps().then((result) => {
+    console.log('fps', performance.now());
+    window.performance_information.frames_per_second = result;
+    print();
+});
+
+TTI.getFirstConsistentlyInteractive().then((result) => {
+    console.log('tti', performance.now());
+    window.performance_information.time_to_interactive = result;
+    print();
+});
+
+function print() {
+    document.querySelector('table').innerHTML = Object.entries(window.performance_information).map(
+        ([key, value]) => `<tr><td>${key}</td><td>${value}</td></tr>`
+    ).join('');
+}

--- a/src/all/index.js
+++ b/src/all/index.js
@@ -10,8 +10,7 @@ import { elapsed } from '../elapsed/index.js';
 /**
  * @returns {object}
  */
-export const all = () => Object.assign(
-    {},
+export const all = async() => await Promise.all([
     navigation(),
     paint(),
     assets(),
@@ -20,4 +19,6 @@ export const all = () => Object.assign(
     display(),
     dom(),
     elapsed()
+]).then(
+    (results) => Object.assign({}, ...results)
 );

--- a/src/assets/index.js
+++ b/src/assets/index.js
@@ -1,3 +1,4 @@
+import { getEntries } from '../getEntries/index.js';
 import { getType } from '../get-type/index.js';
 import { number } from '../number/index.js';
 
@@ -6,22 +7,20 @@ const FINAL_ASSET_PREFIX = 'final_asset';
 /**
  * @returns {object}
  */
-export function assets() {
+export async function assets() {
     if (!window.performance || !window.performance.getEntriesByType) {
         return {};
     }
 
     const metrics = {};
+    const entries = await getEntries('resource');
 
-    window.performance.getEntriesByType('resource').forEach(
-        (entry) => {
-            const type = getType(entry);
-
-            add(metrics, type, 'count', 1);
-            add(metrics, type, 'load', entry.duration);
-            add(metrics, type, 'size', entry.decodedBodySize);
-        }
-    );
+    for (const entry of entries) {
+        const type = await getType(entry);
+        add(metrics, type, 'count', 1);
+        add(metrics, type, 'load', entry.duration);
+        add(metrics, type, 'size', entry.decodedBodySize);
+    }
 
     for (const key in metrics) {
         if (Number.isNaN(metrics[key])) {

--- a/src/assets/spec.js
+++ b/src/assets/spec.js
@@ -19,8 +19,8 @@ describe('assets', () => {
     ].forEach(
         (event) => it(
             event,
-            () => {
-                const data = assets();
+            async() => {
+                const data = await assets();
                 expect(data).to.have.property(event);
                 expect(data[event]).to.be.a('number');
             }

--- a/src/connection/index.js
+++ b/src/connection/index.js
@@ -1,3 +1,4 @@
+import { getEntries } from '../getEntries/index.js';
 import { number } from '../number/index.js';
 
 /**
@@ -17,14 +18,14 @@ const LEGACY_NAVIGATION_TYPES = [
  * @see [NetworkInformation](https://developer.mozilla.org/en-US/docs/Web/API/NetworkInformation)
  * @returns {object}
  */
-export function connection() {
+export async function connection() {
     const { connection } = window.navigator || {};
     const result = {};
 
     try {
         const [
-            navigation = performance.navigation
-        ] = performance.getEntriesByType('navigation');
+            { navigation = performance.navigation } = {}
+        ] = await getEntries('navigation');
 
         result.navigation_type = typeof navigation.type === 'number'
             ? LEGACY_NAVIGATION_TYPES[navigation.type]

--- a/src/connection/spec.js
+++ b/src/connection/spec.js
@@ -2,24 +2,16 @@ import { connection } from './index.js';
 
 const { getEntriesByType } = window.performance;
 
-describe('connection', () => {
+describe('connection', async() => {
     afterEach(() => {
         window.performance.getEntriesByType = getEntriesByType;
     });
-    it('should find navigation timing', () => {
-        const { navigation_type } = connection();
+    it('should find navigation timing', async() => {
+        const { navigation_type } = await connection();
 
         expect(navigation_type).to.equal('navigate');
     });
-    it('should find navigation on legacy object', () => {
-        window.performance.getEntriesByType = () => [];
-        expect(performance.getEntriesByType('navigation')).to.have.lengthOf(0);
-        const { navigation_type } = connection();
-
-        expect(navigation_type).to.equal('navigate');
-    });
-
-    it('should expose supported metrics', () => {
+    it('should expose supported metrics', async() => {
         const {
             connection_type,
             effective_bandwidth,
@@ -27,7 +19,7 @@ describe('connection', () => {
             effective_max_bandwidth,
             reduced_data_usage,
             round_trip_time
-        } = connection();
+        } = await connection();
 
         expect(connection_type).to.be.undefined; // Not yet exposed by Chrome
         expect(effective_bandwidth).to.be.a('number');

--- a/src/display/index.js
+++ b/src/display/index.js
@@ -3,7 +3,7 @@ import { number } from '../number/index.js';
 /**
  * @returns {object}
  */
-export function display() {
+export async function display() {
     const result = {
         window_inner_height: number(window.innerHeight),
         window_inner_width: number(window.innerWidth)

--- a/src/display/spec.js
+++ b/src/display/spec.js
@@ -7,16 +7,16 @@ describe('display', () => {
     ].forEach(
         (event) => it(
             `Screen metric ${event}`,
-            () => {
-                const data = display();
+            async() => {
+                const data = await display();
                 expect(data).to.have.property(event);
                 expect(data[event]).to.be.a('number');
             }
         )
     );
 
-    it('Screen orientation', () => {
-        const data = display();
+    it('Screen orientation', async() => {
+        const data = await display();
         expect(data).to.have.property('screen_orientation_type');
         expect(data.screen_orientation_type).to.be.a('string');
     });

--- a/src/dom/index.js
+++ b/src/dom/index.js
@@ -15,7 +15,7 @@ function getMaxNestLevel(depth = 1) {
  * Get stats on a DOM tree safely
  * @returns {object}
  */
-export function dom() {
+export async function dom() {
     try {
         return {
             final_dom_node_count: number(document.querySelectorAll('*').length),

--- a/src/dom/spec.js
+++ b/src/dom/spec.js
@@ -10,8 +10,8 @@ describe('dom', () => {
     ].forEach(
         (event) => it(
             `DOM metric ${event}`,
-            () => {
-                const data = dom();
+            async() => {
+                const data = await dom();
                 expect(data).to.have.property(event);
                 expect(data[event]).to.be.a('number');
             }
@@ -51,18 +51,18 @@ describe('dom', () => {
             expect(d.querySelector('body article p strong')).not.to.equal(null);
         });
 
-        it('Should return the total number of child DOM elements', () => {
-            const { final_dom_node_count } = dom();
+        it('Should return the total number of child DOM elements', async() => {
+            const { final_dom_node_count } = await dom();
             expect(final_dom_node_count).to.equal(18);
         });
 
-        it('Should return the depth of deepest DOM tree', () => {
-            const { final_dom_nest_depth } = dom();
+        it('Should return the depth of deepest DOM tree', async() => {
+            const { final_dom_nest_depth } = await dom();
             expect(final_dom_nest_depth).to.equal(5);
         });
 
-        it('Should return the character count of the HTML document', () => {
-            const { final_html_size } = dom();
+        it('Should return the character count of the HTML document', async() => {
+            const { final_html_size } = await dom();
             expect(final_html_size).to.equal(232);
         });
     });

--- a/src/elapsed/index.js
+++ b/src/elapsed/index.js
@@ -1,4 +1,4 @@
-export function elapsed() {
+export async function elapsed() {
     const page_time_elapsed = window.performance.now();
 
     return Number.isFinite(page_time_elapsed)

--- a/src/elapsed/spec.js
+++ b/src/elapsed/spec.js
@@ -6,8 +6,8 @@ describe('elapsed', () => {
     afterEach(() => {
         window.performance.now = now;
     });
-    it('should returned the time elapsed since the time origin', () => {
-        const { page_time_elapsed } = elapsed();
+    it('should returned the time elapsed since the time origin', async() => {
+        const { page_time_elapsed } = await elapsed();
         expect(page_time_elapsed).to.be.a('number');
         expect(page_time_elapsed).to.be.at.least(50);
     });
@@ -17,9 +17,9 @@ describe('elapsed', () => {
         -10,
         1e3
     ].forEach(
-        (value) => it('should return the result of "performance.now" function', () => {
+        (value) => it('should return the result of "performance.now" function', async() => {
             window.performance.now = () => value;
-            const { page_time_elapsed } = elapsed();
+            const { page_time_elapsed } = await elapsed();
             expect(page_time_elapsed).to.equal(value);
         })
     );
@@ -29,9 +29,9 @@ describe('elapsed', () => {
         Infinity,
         NaN
     ].forEach(
-        (value) => it('should be undefined if not a finite number', () => {
+        (value) => it('should be undefined if not a finite number', async() => {
             window.performance.now = () => value;
-            const result = elapsed();
+            const result = await elapsed();
             expect(result).to.not.have.key('page_time_elapsed');
             const { page_time_elapsed } = result;
             expect(page_time_elapsed).to.equal(undefined);

--- a/src/fps/index.js
+++ b/src/fps/index.js
@@ -3,27 +3,25 @@
  * @param {number} sample Number of seconds to check
  * @returns {number?}
  */
-export function fps({ sample = 1 } = {}) {
-    return new Promise(
-        ((resolve) => {
-            const { requestAnimationFrame } = window;
-            if (!requestAnimationFrame) {
-                resolve(undefined);
-            }
+export const fps = ({ sample = 1 } = {}) => new Promise(
+    ((resolve) => {
+        const { requestAnimationFrame } = window;
+        if (!requestAnimationFrame) {
+            resolve(undefined);
+        }
 
-            const start = window.performance.now();
-            const end = start + (1000 * sample);
-            let frames = 0;
-            requestAnimationFrame(count);
+        const start = window.performance.now();
+        const end = start + (1000 * sample);
+        let frames = 0;
+        requestAnimationFrame(count);
 
-            function count() {
-                if (window.performance.now() > end) {
-                    resolve(frames / sample);
-                } else {
-                    ++frames;
-                    requestAnimationFrame(count);
-                }
+        function count() {
+            if (window.performance.now() > end) {
+                resolve(frames / sample);
+            } else {
+                ++frames;
+                requestAnimationFrame(count);
             }
-        })
-    );
-}
+        }
+    })
+);

--- a/src/get-type/index.js
+++ b/src/get-type/index.js
@@ -60,7 +60,7 @@ const initiators = {
  * @param {string} o.name
  * @returns {string} (images, javascript, stylesheets, other)
  */
-export function getType({ initiatorType, name }) {
+export async function getType({ initiatorType, name }) {
     if (Object.hasOwnProperty.call(initiators, initiatorType)) {
         return initiators[initiatorType];
     }

--- a/src/getEntries/index.js
+++ b/src/getEntries/index.js
@@ -1,0 +1,36 @@
+/**
+ * Retrieve list of PerformanceTiming objects via promise
+ * @param {string}
+ * @returns {Promise<PerformanceEntry[]>}
+ */
+export const getEntries = (...entryTypes) => new Promise(
+    (resolve, reject) => {
+        if (!window.performance) {
+            reject(new Error('Performance API is not supported'));
+            return;
+        }
+
+        const entries = entryTypes.map(
+            (entryType) => window.performance.getEntriesByType(entryType)
+        ).flat();
+
+        if (entries.length) {
+            resolve(entries);
+            return;
+        }
+
+        if (typeof window.PerformanceObserver !== 'function') {
+            reject(new Error('PerformanceObserver is not supported'));
+            return;
+        }
+
+        const observer = new window.PerformanceObserver(
+            (entryList, observer) => {
+                resolve(entryList.getEntries());
+                observer.disconnect();
+            }
+        );
+
+        observer.observe({ entryTypes });
+    }
+);

--- a/src/getEntries/spec.js
+++ b/src/getEntries/spec.js
@@ -1,0 +1,38 @@
+import { getEntries } from './index.js';
+
+const { PerformanceObserver } = window;
+
+describe('getEntries', () => {
+    afterEach(() => {
+        window.PerformanceObserver = PerformanceObserver;
+    });
+    it('should return an empty object when PerformanceObserver is not supported', async() => {
+        delete window.PerformanceObserver;
+        return expect(getEntries()).to.be.rejectedWith('PerformanceObserver is not supported');
+    });
+    it('should return matching entries list by type', async() => {
+        const records = await getEntries('resource');
+        expect(records).to.have.lengthOf.at.least(5);
+        records.forEach(
+            (record) => expect(record).to.be.instanceof(PerformanceResourceTiming)
+        );
+    });
+    it('should return matching entries if they already exist', async() => {
+        expect(
+            window.performance.getEntriesByType('navigation')
+        ).to.have.lengthOf(1);
+
+        const [ navigation ] = await getEntries('navigation');
+        expect(navigation).to.be.instanceof(PerformanceNavigationTiming);
+    });
+    it('should collect multiple types of events and not wait for missing items', async() => {
+        const entries = await getEntries('first-input', 'navigation', 'resource', 'paint');
+        const types = entries.map(
+            ({ entryType }) => entryType
+        );
+        expect(types).to.include('navigation');
+        expect(types).to.include('resource');
+        expect(types).not.to.include('paint');
+        expect(types).not.to.include('first-input');
+    });
+});

--- a/src/memory/index.js
+++ b/src/memory/index.js
@@ -13,7 +13,7 @@ const METRICS = [
 /**
  * @returns {object}
  */
-export function memory() {
+export async function memory() {
     const { memory } = window.performance || {};
     if (!memory) {
         return {};

--- a/src/memory/spec.js
+++ b/src/memory/spec.js
@@ -2,9 +2,9 @@ import { memory } from './index.js';
 
 let data;
 
-describe('memory', () => {
-    before(() => {
-        data = memory();
+describe('memory', async() => {
+    before(async() => {
+        data = await memory();
     });
     [
         'js_heap_size_limit',

--- a/src/navigation/index.js
+++ b/src/navigation/index.js
@@ -1,3 +1,4 @@
+import { getEntries } from '../getEntries/index.js';
 import { number } from '../number/index.js';
 import { snakeCase } from '../snake-case/index.js';
 
@@ -36,26 +37,22 @@ const METRICS = [
 /**
  * @returns {object}
  */
-export function navigation() {
+export async function navigation() {
     const { performance } = window;
     if (!performance || !performance.getEntriesByType) {
         return {};
     }
 
-    const navigationEntries = performance.getEntriesByType('navigation');
+    const [ navigation ] = await getEntries('navigation');
 
-    // PerformanceNavigationTiming interface
-    if (navigationEntries.length) {
+    // console.log(entries.toJSON());
+
+    if (navigation) {
         return Object.assign(
-            {},
-            ...[].concat(
-                ...navigationEntries.map(
-                    (entry) => METRICS.filter(
-                        (metric) => !Number.isNaN(entry[metric])
-                    ).map(
-                        (metric) => ({ [snakeCase(metric)]: number(entry[metric]) })
-                    )
-                )
+            ...METRICS.filter(
+                (metric) => !Number.isNaN(navigation[metric])
+            ).map(
+                (metric) => ({ [snakeCase(metric)]: number(navigation[metric]) })
             )
         );
     }
@@ -67,7 +64,7 @@ export function navigation() {
     const start = performance.timeOrigin || timing.navigationStart;
     if (!start) { return {}; }
 
-    return METRICS.reduce(
+    const result = METRICS.reduce(
         (accumulator, metric) => {
             const value = timing[metric] - start;
             accumulator[snakeCase(metric)] = value < 0
@@ -79,4 +76,6 @@ export function navigation() {
         },
         {}
     );
+
+    return result;
 }

--- a/src/navigation/spec.js
+++ b/src/navigation/spec.js
@@ -3,8 +3,8 @@ import { navigation } from './index.js';
 let data;
 
 describe('navigation', () => {
-    before(() => {
-        data = navigation();
+    before(async() => {
+        data = await navigation();
     });
     [
         'connect_end',

--- a/src/paint/index.js
+++ b/src/paint/index.js
@@ -1,3 +1,4 @@
+import { getEntries } from '../getEntries/index.js';
 import { number } from '../number/index.js';
 import { snakeCase } from '../snake-case/index.js';
 
@@ -5,17 +6,19 @@ import { snakeCase } from '../snake-case/index.js';
  * Retrieve all paint entries
  * @returns {object}
  */
-export function paint() {
+export async function paint() {
     const { performance } = window;
 
     if (!performance || !performance.getEntriesByType) {
         return {};
     }
 
+    const entries = await getEntries('paint');
+
     return Object.assign(
         {},
         ...[].concat(
-            ...performance.getEntriesByType('paint').map(
+            ...entries.map(
                 ({ name, startTime }) => ({ [snakeCase(name)]: number(startTime) })
             )
         )

--- a/src/paint/spec.js
+++ b/src/paint/spec.js
@@ -16,8 +16,8 @@ describe('paint', () => {
     ].forEach(
         (event) => it(
             event,
-            () => {
-                const data = paint();
+            async() => {
+                const data = await paint();
                 expect(data).to.have.property(event);
                 expect(data[event]).to.be.a('number');
             }


### PR DESCRIPTION
- [x] Breaking change
- [x] Tests added

By utilising PerformanceObserver, async interface allows to decouple from waiting for onload event. User can include an async file and not worry about loading time