### PR TITLE
Escape execution after null check

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,10 @@
+# 3.0.1
+
+## Fixes
+
+### Null check for requestAnimationFrame
+Escape execution for "fps" after requestAnimationFrame null check has failed
+
 # 3.0.0
 
 ## Breaking changes

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "page-timing",
-  "version": "3.0.0",
+  "version": "3.0.1",
   "description": "⏱ Collect and measure browser performance metrics",
   "keywords": [
     "browser",

--- a/src/fps/index.js
+++ b/src/fps/index.js
@@ -8,6 +8,7 @@ export const fps = ({ sample = 1 } = {}) => new Promise(
         const { requestAnimationFrame } = window;
         if (!requestAnimationFrame) {
             resolve(undefined);
+            return;
         }
 
         const start = window.performance.now();


### PR DESCRIPTION
- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Deprecations
- [ ] Tests added
- [ ] JSDoc added

Promise was resolved but function execution was not cut. This fix should escape the function when requestAnimationFrame is not supported