### PR TITLE
Add some backwards compatibility for older browsers

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "page-timing",
-  "version": "3.1.0",
+  "version": "3.1.1",
   "description": "⏱ Collect and measure browser performance metrics",
   "keywords": [
     "browser",
@@ -39,7 +39,7 @@
     "@lets/wait": "^2.0.2",
     "chai": "^4.2.0",
     "chai-as-promised": "^7.1.1",
-    "eslint": "^7.17.0",
+    "eslint": "^7.18.0",
     "eslint-plugin-log": "^1.2.7",
     "karma": "^6.0.0",
     "karma-chrome-launcher": "^3.1.0",
@@ -50,6 +50,6 @@
     "regenerator-runtime": "^0.13.7",
     "tti-polyfill": "^0.2.2",
     "web-vitals": "^1.1.0",
-    "webpack": "^5.14.0"
+    "webpack": "^5.15.0"
   }
 }

--- a/play/script.js
+++ b/play/script.js
@@ -36,7 +36,7 @@ window.addEventListener(
 
         TTI.getFirstConsistentlyInteractive().then((result) => {
             console.log('tti', performance.now());
-            window.performance_information.time_to_interactive = result;
+            window.performance_information.time_to_interactive = result || undefined;
             print();
         }).catch(console.error);
 

--- a/src/assets/index.js
+++ b/src/assets/index.js
@@ -1,6 +1,6 @@
 import { getEntries } from '../getEntries/index.js';
 import { getType } from '../get-type/index.js';
-import { number } from '../number/index.js';
+import { number, isNaN } from '../number/index.js';
 
 const FINAL_ASSET_PREFIX = 'final_asset';
 
@@ -23,7 +23,7 @@ export async function assets() {
     }
 
     for (const key in metrics) {
-        if (Number.isNaN(metrics[key])) {
+        if (isNaN(metrics[key])) {
             metrics[key] = undefined;
         }
     }

--- a/src/elapsed/index.js
+++ b/src/elapsed/index.js
@@ -1,7 +1,9 @@
+import { isFinite } from '../number/index.js';
+
 export async function elapsed() {
     const page_time_elapsed = window.performance.now();
 
-    return Number.isFinite(page_time_elapsed)
+    return isFinite(page_time_elapsed)
         ? { page_time_elapsed }
         : {}
     ;

--- a/src/getEntries/index.js
+++ b/src/getEntries/index.js
@@ -10,9 +10,11 @@ export const getEntries = (...entryTypes) => new Promise(
             return;
         }
 
-        const entries = entryTypes.map(
-            (entryType) => window.performance.getEntriesByType(entryType)
-        ).flat();
+        const entries = [].concat(
+            ...entryTypes.map(
+                (entryType) => window.performance.getEntriesByType(entryType)
+            )
+        );
 
         if (entries.length) {
             resolve(entries);

--- a/src/navigation/index.js
+++ b/src/navigation/index.js
@@ -1,5 +1,5 @@
 import { getEntries } from '../getEntries/index.js';
-import { number } from '../number/index.js';
+import { number, isNaN } from '../number/index.js';
 import { snakeCase } from '../snake-case/index.js';
 
 /**
@@ -49,7 +49,7 @@ export async function navigation() {
     if (navigation) {
         return Object.assign(
             ...METRICS.filter(
-                (metric) => !Number.isNaN(navigation[metric])
+                (metric) => !isNaN(navigation[metric])
             ).map(
                 (metric) => ({ [snakeCase(metric)]: number(navigation[metric]) })
             )

--- a/src/number/index.js
+++ b/src/number/index.js
@@ -32,3 +32,8 @@ export function number(input) {
 
     return value;
 }
+
+export {
+    isNaN,
+    isFinite
+};


### PR DESCRIPTION
Remove use of Array.flat, and supply a fallback for Number.isNaN and Number.isFinite