### PR TITLE
Escape observer with empty entryTypes

### DIFF
--- a/.karma/index.js
+++ b/.karma/index.js
@@ -3,9 +3,7 @@ const browsers = ['Chrome'];
 const watch = process.env.npm_config_watch;
 const ENV_SETUP = resolve(`${__dirname}/env-setup.js`);
 const browserNoActivityTimeout = 1 * 60 * 1000;
-const pattern = ((args) =>
-    `../src/${args.length ? `**/+(${args.join('|')})` : '**'}/spec.js`
-)(JSON.parse(process.env.npm_config_argv).remain);
+const pattern = '../src/**/spec.js';
 
 module.exports = (config) => {
     const {LOG_INFO} = config;

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "page-timing",
-  "version": "3.1.1",
+  "version": "3.1.2",
   "description": "⏱ Collect and measure browser performance metrics",
   "keywords": [
     "browser",

--- a/src/getEntries/index.js
+++ b/src/getEntries/index.js
@@ -10,6 +10,11 @@ export const getEntries = (...entryTypes) => new Promise(
             return;
         }
 
+        if (!entryTypes.length) {
+            reject(new TypeError('A Performance Observer must have a non-empty entryTypes attribute'));
+            return;
+        }
+
         const entries = [].concat(
             ...entryTypes.map(
                 (entryType) => window.performance.getEntriesByType(entryType)

--- a/src/getEntries/spec.js
+++ b/src/getEntries/spec.js
@@ -1,15 +1,26 @@
 import { getEntries } from './index.js';
 
-const { PerformanceObserver } = window;
+const { performance } = window;
 
 describe('getEntries', () => {
     afterEach(() => {
-        window.PerformanceObserver = PerformanceObserver;
+        Object.assign(
+            window,
+            { performance }
+        );
     });
-    it('should return an empty object when PerformanceObserver is not supported', async() => {
-        delete window.PerformanceObserver;
-        return expect(getEntries()).to.be.rejectedWith('PerformanceObserver is not supported');
+    it('should return an empty object when performance API is not supported', async() => {
+        delete window.performance;
+        return expect(getEntries('navigation')).to.be.rejectedWith('Performance API is not supported');
     });
+    it(
+        'should return an empty object when no entryTypes were passed through',
+        async() => expect(
+            getEntries()
+        ).to.be.rejectedWith(
+            'A Performance Observer must have a non-empty entryTypes attribute'
+        )
+    );
     it('should return matching entries list by type', async() => {
         const records = await getEntries('resource');
         expect(records).to.have.lengthOf.at.least(5);


### PR DESCRIPTION
- [x] Bug fix
- [x] Tests added

"Failed to execute 'observe' on 'PerformanceObserver': A Performance Observer MUST have a non-empty entryTypes attribute."