### PR TITLE
[FIX] Reject observer for unsupported entry types

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "page-timing",
-  "version": "3.1.2",
+  "version": "3.1.3",
   "description": "⏱ Collect and measure browser performance metrics",
   "keywords": [
     "browser",

--- a/src/getEntries/index.js
+++ b/src/getEntries/index.js
@@ -5,39 +5,48 @@
  */
 export const getEntries = (...entryTypes) => new Promise(
     (resolve, reject) => {
-        if (!window.performance) {
-            reject(new Error('Performance API is not supported'));
-            return;
-        }
-
-        if (!entryTypes.length) {
-            reject(new TypeError('A Performance Observer must have a non-empty entryTypes attribute'));
-            return;
-        }
-
-        const entries = [].concat(
-            ...entryTypes.map(
-                (entryType) => window.performance.getEntriesByType(entryType)
-            )
-        );
-
-        if (entries.length) {
-            resolve(entries);
-            return;
-        }
-
-        if (typeof window.PerformanceObserver !== 'function') {
-            reject(new Error('PerformanceObserver is not supported'));
-            return;
-        }
-
-        const observer = new window.PerformanceObserver(
-            (entryList, observer) => {
-                resolve(entryList.getEntries());
-                observer.disconnect();
+        try {
+            if (!window.performance) {
+                reject(new Error('Performance API is not supported'));
+                return;
             }
-        );
 
-        observer.observe({ entryTypes });
+            if (!entryTypes.length) {
+                reject(new TypeError('A Performance Observer must have a non-empty entryTypes attribute'));
+                return;
+            }
+
+            const entries = [].concat(
+                ...entryTypes.map(
+                    (entryType) => window.performance.getEntriesByType(entryType)
+                )
+            );
+
+            if (entries.length) {
+                resolve(entries);
+                return;
+            }
+
+            if (typeof window.PerformanceObserver !== 'function') {
+                reject(new Error('PerformanceObserver is not supported'));
+                return;
+            }
+
+            const observer = new window.PerformanceObserver(
+                (entryList, observer) => {
+                    resolve(entryList.getEntries());
+                    observer.disconnect();
+                }
+            );
+
+            try {
+                observer.observe({ entryTypes });
+            } catch (error) {
+                observer.disconnect();
+                reject(error);
+            }
+        } catch (error) {
+            reject(error);
+        }
     }
 );


### PR DESCRIPTION
- [x] Bug fix

Error:
```
Failed to execute 'observe' on 'PerformanceObserver': A Performance Observer MUST have at least one valid entryType in its entryTypes attribute.
```